### PR TITLE
[fix errors] 'MarkdownInstance' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

### DIFF
--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -1,5 +1,5 @@
 ---
-import { MarkdownInstance } from 'astro/dist/@types/astro';
+import { type MarkdownInstance } from 'astro/dist/@types/astro';
 import Section from './Section.astro';
 import Card from './Card.astro';
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,7 +4,7 @@ import Card from '@/components/Card.astro';
 import Base from '@/layouts/Base.astro';
 import Heading from '@/components/Heading.astro';
 import { AppConfig } from '@/utils/AppConfig';
-import { MarkdownInstance } from 'astro/dist/@types/astro';
+import { type MarkdownInstance } from 'astro/dist/@types/astro';
 
 export async function getStaticPaths(): Promise<any> {
 	const allPosts = await Astro.glob('../posts/*.md');

--- a/src/utils/data.util.ts
+++ b/src/utils/data.util.ts
@@ -1,4 +1,4 @@
-import { MarkdownInstance } from "astro";
+import { type MarkdownInstance } from "astro";
 
 export const formatDate = (pubDate: string) => {
   var options: Intl.DateTimeFormatOptions = {


### PR DESCRIPTION
- https://zenn.dev/teppeis/articles/2023-04-typescript-5_0-verbatim-module-syntax
